### PR TITLE
Expand CV site with full LinkedIn profile — Skills, Education, and rich Work history

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1359,13 +1359,13 @@ input, select, textarea {
 
 				#header nav ul li a {
 					display: block;
-					min-width: 7.5rem;
+					min-width: 6.5rem;
 					height: 2.75rem;
 					line-height: 2.75rem;
-					padding: 0 1.25rem 0 1.45rem;
+					padding: 0 0.9rem 0 1rem;
 					text-transform: uppercase;
-					letter-spacing: 0.2rem;
-					font-size: 0.8rem;
+					letter-spacing: 0.12rem;
+					font-size: 0.75rem;
 					border-bottom: 0;
 				}
 
@@ -1660,3 +1660,240 @@ input, select, textarea {
 		body.is-preload #footer {
 			opacity: 0;
 		}
+
+/* === Custom CV additions === */
+
+/* --- Highlights grid (About) --- */
+.cb-highlights {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem 1.5rem;
+    margin: 0 0 2rem 0;
+}
+
+.cb-highlight-item {
+    border-top: solid 1px rgba(255, 255, 255, 0.2);
+    padding-top: 0.75rem;
+}
+
+.cb-highlight-item--wide {
+    grid-column: 1 / -1;
+}
+
+.cb-highlight-label {
+    display: block;
+    font-size: 0.65rem;
+    font-weight: 600;
+    letter-spacing: 0.2rem;
+    text-transform: uppercase;
+    opacity: 0.6;
+    margin-bottom: 0.25rem;
+}
+
+.cb-highlight-value {
+    display: block;
+    font-size: 0.85rem;
+    line-height: 1.5;
+}
+
+@media screen and (max-width: 480px) {
+    .cb-highlights {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* --- Timeline container (Work and Education) --- */
+.cb-timeline {
+    margin: 0 0 2rem 0;
+}
+
+/* --- Job disclosure items (Work) --- */
+.cb-job {
+    border-top: solid 1px rgba(255, 255, 255, 0.2);
+    padding: 0.75rem 0;
+}
+
+.cb-job:first-child {
+    border-top: 0;
+    padding-top: 0;
+}
+
+.cb-job summary {
+    list-style: none;
+    cursor: pointer;
+    outline: none;
+    transition: opacity 0.2s ease-in-out;
+}
+
+.cb-job summary:hover {
+    opacity: 0.75;
+}
+
+.cb-job summary::-webkit-details-marker {
+    display: none;
+}
+
+.cb-job summary::marker {
+    display: none;
+}
+
+.cb-job-header {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.1rem 0;
+    padding-right: 1.5rem;
+    position: relative;
+}
+
+.cb-job summary::after {
+    content: '+';
+    position: absolute;
+    right: 0;
+    top: 0;
+    font-size: 1.2rem;
+    font-weight: 300;
+    opacity: 0.5;
+    line-height: 1;
+}
+
+.cb-job[open] summary::after {
+    content: '\2212';
+}
+
+.cb-job-title {
+    display: block;
+    font-size: 0.8rem;
+    opacity: 0.85;
+}
+
+.cb-job-meta {
+    display: block;
+    font-size: 0.65rem;
+    letter-spacing: 0.1rem;
+    text-transform: uppercase;
+    opacity: 0.55;
+    margin-top: 0.15rem;
+}
+
+.cb-job[open] {
+    border-left: solid 2px rgba(255, 255, 255, 0.25);
+    padding-left: 0.75rem;
+    margin-left: -0.75rem;
+}
+
+.cb-job-details {
+    list-style: disc;
+    padding-left: 1.2rem;
+    margin: 0.75rem 0 0.25rem 0;
+    font-size: 0.85rem;
+    line-height: 1.7;
+}
+
+.cb-job-details li {
+    padding-left: 0.25rem;
+    margin-bottom: 0.3rem;
+}
+
+/* --- Education items --- */
+.cb-edu-item {
+    border-top: solid 1px rgba(255, 255, 255, 0.2);
+    padding: 0.75rem 0;
+}
+
+.cb-edu-item:first-child {
+    border-top: 0;
+    padding-top: 0;
+}
+
+.cb-edu-note {
+    font-size: 0.8rem;
+    opacity: 0.7;
+    margin: 0.25rem 0 0 0;
+    font-style: italic;
+}
+
+/* --- Skill category headings --- */
+.cb-skill-category {
+    font-size: 0.7rem;
+    letter-spacing: 0.2rem;
+    text-transform: uppercase;
+    opacity: 0.6;
+    margin: 1.5rem 0 0.6rem 0;
+    font-weight: 600;
+    border-bottom: none;
+}
+
+.cb-skill-category:first-of-type {
+    margin-top: 0;
+}
+
+/* --- Skill chips --- */
+.cb-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-bottom: 0.5rem;
+}
+
+.cb-chip {
+    display: inline-block;
+    font-size: 0.72rem;
+    font-weight: 300;
+    letter-spacing: 0.05rem;
+    padding: 0.25rem 0.65rem;
+    border-radius: 2rem;
+    background-color: rgba(255, 255, 255, 0.1);
+    border: solid 1px rgba(255, 255, 255, 0.3);
+    white-space: nowrap;
+}
+
+/* --- Certification badges (Education) --- */
+.cb-badges {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    margin: 0 0 2rem 0;
+}
+
+.cb-badge {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    font-size: 0.82rem;
+    padding: 0.55rem 0.75rem;
+    background-color: rgba(255, 255, 255, 0.07);
+    border: solid 1px rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+    line-height: 1.3;
+}
+
+
+.cb-badge small {
+    margin-left: auto;
+    font-size: 0.65rem;
+    opacity: 0.55;
+    letter-spacing: 0.05rem;
+    white-space: nowrap;
+}
+
+.cb-badge-icon {
+    opacity: 0.7;
+    flex-shrink: 0;
+}
+
+.cb-badge-name {
+    flex: 1;
+    min-width: 0;
+}
+
+@media screen and (max-width: 480px) {
+    .cb-badge {
+        flex-wrap: wrap;
+    }
+    .cb-badge small {
+        margin-left: 0;
+        width: 100%;
+    }
+}
+
+/* === End custom CV additions === */

--- a/index.html
+++ b/index.html
@@ -35,16 +35,16 @@
 			<div class="content">
 				<div class="inner">
 					<h1>Hi, I'm Charl Brill</h1>
-					<p>I am absolutely fascinated by the potential of technology and how we use data to improve decision-making capabilities. This site explains a bit about me.</p>
+					<p>Senior Data Engineer &middot; Microsoft Fabric &middot; Databricks &middot; AWS &middot; Azure<br />Turning complex data challenges into scalable solutions.</p>
 				</div>
 			</div>
 			<nav>
 				<ul>
-					<!-- <li><a href="#intro">Intro</a></li> -->
 					<li><a href="#about">About</a></li>
 					<li><a href="#work">Work</a></li>
+					<li><a href="#skills">Skills</a></li>
+					<li><a href="#education">Education</a></li>
 					<li><a href="#contact">Contact</a></li>
-					<!--<li><a href="#elements">Elements</a></li>-->
 				</ul>
 			</nav>
 		</header>
@@ -66,41 +66,279 @@
 					<li><a href="https://drive.google.com/file/d/1GP0ZYQAYqImh8qYZ3ZlEsEh-K8rXhb8_/view?usp=sharing" target="_blank" class="button primary icon solid fa-file-alt">View Resume</a></li>
 				</ul>
 				<span class="image main"><img src="images/nordwood-themes-bJjsKbToY34-unsplash.jpg" alt="Work" /></span>
-				<ul class="alt" style="margin-bottom: 2rem;">
-					<li>
-						<strong><a href="https://www.longviewsystems.com/">Long View Systems</a></strong><br>
-						Data Engineer (Consultant)<br>
-						<small style="opacity:0.65; letter-spacing:0.1rem; text-transform:uppercase; font-size:0.7rem;">October 2023 — Present</small>
-					</li>
-					<li>
-						<strong><a href="https://www.agrigateone.com/">AgrigateOne</a></strong><br>
-						Head of Data Science and Data Analytics<br>
-						<small style="opacity:0.65; letter-spacing:0.1rem; text-transform:uppercase; font-size:0.7rem;">August 2020 — September 2023</small>
-					</li>
-					<li>
-						<strong><a href="https://decisioninc.com/">Decision Inc.</a></strong><br>
-						Business Intelligence Consultant<br>
-						<small style="opacity:0.65; letter-spacing:0.1rem; text-transform:uppercase; font-size:0.7rem;">April 2019 — July 2020</small>
-					</li>
-					<li>
-						<strong>Burlington Strategy Advisors</strong><br>
-						Analyst<br>
-						<small style="opacity:0.65; letter-spacing:0.1rem; text-transform:uppercase; font-size:0.7rem;">July 2014 — September 2017</small>
-					</li>
-					<li>
-						<strong><a href="https://www.mintek.co.za">Mintek</a></strong><br>
-						Project Engineer<br>
-						<small style="opacity:0.65; letter-spacing:0.1rem; text-transform:uppercase; font-size:0.7rem;">January 2013 — June 2014</small>
-					</li>
-				</ul>
+
+				<div class="cb-timeline">
+
+					<details class="cb-job">
+						<summary>
+							<div class="cb-job-header">
+								<strong><a href="https://www.dataelephant.com" target="_blank" rel="noopener">Data Elephant</a></strong>
+								<span class="cb-job-title">Senior Data Engineer</span>
+								<small class="cb-job-meta">Jul 2025 &ndash; Present &middot; Vancouver, Remote</small>
+							</div>
+						</summary>
+						<ul class="cb-job-details">
+							<li>Translate business requirements into technical data solutions across AWS, Azure, and Databricks cloud platforms; build end-to-end ETL/ELT pipelines using SQL, Python, PySpark, and Glue.</li>
+							<li>Pre-sales meetings, client proposals, and technical networking events.</li>
+							<li>Cross-functional collaboration with data scientists, MLOps engineers, and full-stack developers in agile/DevOps environments.</li>
+							<li>Drive AI/ML pilots and proofs of concept; maintain Microsoft and Databricks certifications.</li>
+							<li>Support recruitment and mentoring as the team grows.</li>
+						</ul>
+					</details>
+
+					<details class="cb-job">
+						<summary>
+							<div class="cb-job-header">
+								<strong><a href="https://www.longviewsystems.com/" target="_blank" rel="noopener">Long View Systems</a></strong>
+								<span class="cb-job-title">Data Engineer</span>
+								<small class="cb-job-meta">Oct 2023 &ndash; Jun 2025 &middot; Vancouver, Hybrid</small>
+							</div>
+						</summary>
+						<ul class="cb-job-details">
+							<li>Co-developed a deployable framework to ingest data from multiple source systems and streamline reporting using Fabric, PySpark, SparkSQL, and PowerBI.</li>
+							<li>Implemented end-to-end medallion architecture analytics on Microsoft Fabric Lakehouse with Azure Data Factory.</li>
+							<li>Built a call metrics monitoring solution from ingestion to reporting using Microsoft Fabric and ADF.</li>
+							<li>Conducted PowerBI migration investigations and implemented a REST API monitoring solution for PowerBI deployments.</li>
+							<li>Designed an inventory monitoring solution across the supply chain using Fabric, ADF, Lakehouse modelling, and PowerBI.</li>
+							<li>Developed ETL pipelines in Databricks with SQL; built a Python module for AES encryption key rotation via Azure Key Vault.</li>
+						</ul>
+					</details>
+
+					<details class="cb-job">
+						<summary>
+							<div class="cb-job-header">
+								<strong><a href="https://www.agrigateone.com/" target="_blank" rel="noopener">AgrigateOne</a></strong>
+								<span class="cb-job-title">Head of Data Science &amp; Analytics</span>
+								<small class="cb-job-meta">Aug 2020 &ndash; Oct 2023</small>
+							</div>
+						</summary>
+						<ul class="cb-job-details">
+							<li>Product owner and lead for all data analytics and data science projects.</li>
+							<li>Developed and communicated project roadmaps; managed stakeholder expectations.</li>
+							<li>Agile product management using Jira, Confluence, Shape Up, and Git.</li>
+							<li>Designed BI solution on Metabase and PostgreSQL for platform stakeholders (growers and buyers).</li>
+							<li>Led data strategy and digital transformation initiatives.</li>
+							<li>Architected data warehouse on AWS (Lambda, RDS, S3).</li>
+							<li>Delivered ML and process automation solutions in Python.</li>
+						</ul>
+					</details>
+
+					<details class="cb-job">
+						<summary>
+							<div class="cb-job-header">
+								<strong><a href="https://decisioninc.com/" target="_blank" rel="noopener">Decision Inc.</a></strong>
+								<span class="cb-job-title">Business Intelligence Consultant</span>
+								<small class="cb-job-meta">Apr 2019 &ndash; Jul 2020 &middot; Johannesburg, SA</small>
+							</div>
+						</summary>
+						<ul class="cb-job-details">
+							<li>Deployed a Big Data Qlik model for a major South African retailer on AWS Redshift.</li>
+							<li>Advanced analytics using Alteryx, KNIME, and Python: operations injury driver analysis, sales forecasting, demand planning, and procurement spend analysis.</li>
+							<li>Conducted information landscape audits across healthcare, retail, manufacturing, and banking to align corporate and data strategies.</li>
+							<li>BI development in PowerBI, Qlik Sense, QlikView, and Tableau.</li>
+							<li>Business analysis and requirements gathering using Agile methodology.</li>
+							<li>Spearheaded a company-wide data literacy initiative.</li>
+						</ul>
+					</details>
+
+					<details class="cb-job">
+						<summary>
+							<div class="cb-job-header">
+								<strong>Burlington Strategy Advisors</strong>
+								<span class="cb-job-title">Business Analyst</span>
+								<small class="cb-job-meta">Jul 2014 &ndash; Sep 2017</small>
+							</div>
+						</summary>
+						<ul class="cb-job-details">
+							<li>Built a property development financial model forecasting cash flows using Excel VBA.</li>
+							<li>Developed a techno-financial model for a large-scale trigeneration project (heated water, chilled water, and electricity generation).</li>
+							<li>Designed a capital portfolio optimisation algorithm for one of South Africa's largest capital portfolios using Excel VBA and C#.</li>
+							<li>Implemented a large-scale KPI measurement system using Excel VBA.</li>
+						</ul>
+					</details>
+
+					<details class="cb-job">
+						<summary>
+							<div class="cb-job-header">
+								<strong><a href="https://www.mintek.co.za" target="_blank" rel="noopener">Mintek</a></strong>
+								<span class="cb-job-title">Project Engineer (Head of Design Office)</span>
+								<small class="cb-job-meta">Jan 2013 &ndash; Jun 2014</small>
+							</div>
+						</summary>
+						<ul class="cb-job-details">
+							<li>Led the design office and managed new projects focused on pilot plant equipment design and site layouts.</li>
+							<li>Delivered designs using AutoCAD, Inventor, and SolidWorks.</li>
+							<li>Researched, designed, and procured mining equipment for small-scale mining clients.</li>
+						</ul>
+					</details>
+
+					<details class="cb-job">
+						<summary>
+							<div class="cb-job-header">
+								<strong><a href="https://www.mintek.co.za" target="_blank" rel="noopener">Mintek</a></strong>
+								<span class="cb-job-title">Mechanical Engineering Intern</span>
+								<small class="cb-job-meta">Nov 2011 &ndash; Jan 2012</small>
+							</div>
+						</summary>
+						<ul class="cb-job-details">
+							<li>Designed and optimised granite cutting equipment; presented final design to Mintek CEO and supervisors.</li>
+						</ul>
+					</details>
+
+				</div>
+			</article>
+
+			<!-- Skills -->
+			<article id="skills">
+				<h2 class="major">Skills</h2>
+
+				<h3 class="cb-skill-category">Cloud Platforms</h3>
+				<div class="cb-chips">
+					<span class="cb-chip">Microsoft Azure</span>
+					<span class="cb-chip">AWS</span>
+					<span class="cb-chip">Azure Databricks</span>
+					<span class="cb-chip">Microsoft Fabric</span>
+					<span class="cb-chip">Azure Data Factory</span>
+					<span class="cb-chip">Azure Key Vault</span>
+					<span class="cb-chip">AWS Redshift</span>
+					<span class="cb-chip">AWS Lambda</span>
+					<span class="cb-chip">AWS S3 / RDS</span>
+					<span class="cb-chip">AWS Glue</span>
+				</div>
+
+				<h3 class="cb-skill-category">Data Engineering</h3>
+				<div class="cb-chips">
+					<span class="cb-chip">PySpark</span>
+					<span class="cb-chip">SparkSQL</span>
+					<span class="cb-chip">Python</span>
+					<span class="cb-chip">SQL</span>
+					<span class="cb-chip">dbt</span>
+					<span class="cb-chip">ETL / ELT</span>
+					<span class="cb-chip">Data Modeling</span>
+					<span class="cb-chip">Medallion Architecture</span>
+					<span class="cb-chip">Data Warehousing</span>
+					<span class="cb-chip">PostgreSQL</span>
+				</div>
+
+				<h3 class="cb-skill-category">BI &amp; Analytics</h3>
+				<div class="cb-chips">
+					<span class="cb-chip">Power BI</span>
+					<span class="cb-chip">Qlik Sense</span>
+					<span class="cb-chip">QlikView</span>
+					<span class="cb-chip">Tableau</span>
+					<span class="cb-chip">Metabase</span>
+					<span class="cb-chip">Alteryx</span>
+					<span class="cb-chip">KNIME</span>
+				</div>
+
+				<h3 class="cb-skill-category">Tools &amp; Methods</h3>
+				<div class="cb-chips">
+					<span class="cb-chip">Product Management</span>
+					<span class="cb-chip">Agile / Scrum</span>
+					<span class="cb-chip">DevOps</span>
+					<span class="cb-chip">Git</span>
+					<span class="cb-chip">Jira</span>
+					<span class="cb-chip">Confluence</span>
+					<span class="cb-chip">MLOps</span>
+					<span class="cb-chip">AI / ML Pilots</span>
+					<span class="cb-chip">Data Strategy</span>
+					<span class="cb-chip">Excel VBA</span>
+					<span class="cb-chip">C# / .NET</span>
+					<span class="cb-chip">AutoCAD</span>
+					<span class="cb-chip">SolidWorks</span>
+				</div>
+			</article>
+
+			<!-- Education -->
+			<article id="education">
+				<h2 class="major">Education</h2>
+
+				<div class="cb-timeline">
+
+					<div class="cb-edu-item">
+						<strong>Master of Business Administration (MBA)</strong>
+						<span class="cb-job-title">GIBS Business School (Gordon Institute of Business Science)</span>
+						<small class="cb-job-meta">2018 &ndash; 2019</small>
+					</div>
+
+					<div class="cb-edu-item">
+						<strong>Exchange Programme</strong>
+						<span class="cb-job-title">Indiana University &mdash; Kelley School of Business</span>
+						<small class="cb-job-meta">2018</small>
+						<p class="cb-edu-note">Predictive Analytics &amp; Data Mining &middot; New Product Management &middot; International Business Environment</p>
+					</div>
+
+					<div class="cb-edu-item">
+						<strong>Postgraduate Diploma <em>Cum Laude</em> (78%)</strong>
+						<span class="cb-job-title">GIBS Business School</span>
+						<small class="cb-job-meta">2017 &ndash; 2018</small>
+						<p class="cb-edu-note">Top student overall &middot; Highest mark in 5 of 12 subjects</p>
+					</div>
+
+					<div class="cb-edu-item">
+						<strong>B.Eng Mechanical Engineering <em>Cum Laude</em> (80.2%)</strong>
+						<span class="cb-job-title">Stellenbosch University</span>
+						<small class="cb-job-meta">2009 &ndash; 2012</small>
+						<p class="cb-edu-note">Graduated 2nd in class &middot; Golden Key International Honour Society</p>
+					</div>
+
+				</div>
+
+				<hr />
+				<h3 class="cb-skill-category">Certifications</h3>
+				<div class="cb-badges">
+					<span class="cb-badge">
+						<span class="cb-badge-icon icon brands fa-microsoft"></span>
+						<span class="cb-badge-name">Microsoft Certified: Fabric Data Engineer Associate</span>
+						<small>Jun 2025</small>
+					</span>
+					<span class="cb-badge">
+						<span class="cb-badge-icon icon brands fa-microsoft"></span>
+						<span class="cb-badge-name">Microsoft Certified: Fabric Analytics Engineer Associate</span>
+						<small>May 2024</small>
+					</span>
+					<span class="cb-badge">
+						<span class="cb-badge-icon icon solid fa-database"></span>
+						<span class="cb-badge-name">dbt Fundamentals</span>
+						<small>May 2025</small>
+					</span>
+					<span class="cb-badge">
+						<span class="cb-badge-icon icon brands fa-microsoft"></span>
+						<span class="cb-badge-name">Microsoft Certified: Azure Fundamentals</span>
+						<small>Nov 2023</small>
+					</span>
+					<span class="cb-badge">
+						<span class="cb-badge-icon icon solid fa-robot"></span>
+						<span class="cb-badge-name">Databricks: Generative AI Fundamentals</span>
+						<small>Nov 2023</small>
+					</span>
+				</div>
 			</article>
 
 			<!-- About -->
 			<article id="about">
 				<h2 class="major">About</h2>
-				<span class="image main"><img src="images/andy-hermawan-bVBvv5xlX3g-unsplash.jpg" alt="" /></span>
+				<span class="image main"><img src="images/andy-hermawan-bVBvv5xlX3g-unsplash.jpg" alt="About" /></span>
 				<blockquote>Engineer by trade, problem solver by passion.</blockquote>
-				<p>A seasoned Data Product Manager who transforms complex challenges into high-value solutions with the precision of an engineer — while secretly wishing all life’s decisions could be optimized with a well-structured spreadsheet.</p>
+				<p>An experienced data professional who combines a systems thinking mindset (engineering) with critical reasoning skills (MBA). Driven by the need to use data, analytics and strategic reasoning to ensure evidence-based decision making for future generations.</p>
+				<div class="cb-highlights">
+					<div class="cb-highlight-item">
+						<span class="cb-highlight-label">Location</span>
+						<span class="cb-highlight-value">Maple Ridge, BC, Canada</span>
+					</div>
+					<div class="cb-highlight-item">
+						<span class="cb-highlight-label">Current Role</span>
+						<span class="cb-highlight-value">Senior Data Engineer — Data Elephant</span>
+					</div>
+					<div class="cb-highlight-item cb-highlight-item--wide">
+						<span class="cb-highlight-label">Honours</span>
+						<span class="cb-highlight-value">Cum Laude &times;2 &middot; Top GIBS student &middot; 2nd in Mechanical Engineering class &middot; GMAT 670 (82nd percentile)</span>
+					</div>
+					<div class="cb-highlight-item">
+						<span class="cb-highlight-label">Languages</span>
+						<span class="cb-highlight-value">English &middot; Afrikaans</span>
+					</div>
+				</div>
 			</article>
 
 			<!-- Contact -->


### PR DESCRIPTION
## Summary

Full expansion of the CV/portfolio site using Charl's LinkedIn profile data. The site goes from 3 sparse sections to 5 content-rich sections with detailed professional history, skills, and education.

## What changed

### New sections
- **Skills** — 4 chip-tag categories: Cloud Platforms (Azure, AWS, Fabric, Databricks, ADF, Glue…), Data Engineering (PySpark, Python, SQL, dbt, ETL/ELT, Medallion Architecture…), BI & Analytics (Power BI, Qlik, Tableau, Metabase, Alteryx…), Tools & Methods (Agile, DevOps, Git, Jira, MLOps, Product Management…)
- **Education** — 4 degree entries (MBA at GIBS, Indiana University exchange, GIBS PGDip Cum Laude 78%, Stellenbosch B.Eng Cum Laude 80.2%) + 5 certification badges (Microsoft Fabric DE Associate, Fabric AE Associate, dbt Fundamentals, Azure Fundamentals, Databricks GenAI Fundamentals)

### Expanded existing sections
- **About** — full LinkedIn bio, tagline blockquote, 2-column highlights grid (Location, Current Role, Honours × 4, Languages)
- **Work** — 7 collapsible `<details>`/`<summary>` job entries with bullet-point descriptions, from Data Elephant (Jul 2025–Present) through Mintek intern (2011). Resume CTA button retained at top.
- **Header** — subtitle updated to: *"Senior Data Engineer · Microsoft Fabric · Databricks · AWS · Azure — Turning complex data challenges into scalable solutions."*
- **Nav** — expanded from 3 to 5 items (About | Work | Skills | Education | Contact)

### CSS (main.css)
Custom `cb-` prefixed component block appended (~235 lines):
- Highlights grid with responsive single-column fallback
- Collapsible job timeline with +/− chevron indicator and hover/open states
- Skill chip pills (flex-wrapped)
- Certification badges (flex row, date pushed right)
- Responsive breakpoints for badges and highlights

## Reviewer notes
- All changes in `index.html` and `assets/css/main.css` only — no new files, no JS changes
- `#intro` and `#elements` articles are untouched (still present but unlinked)
- `<details>`/`<summary>` is native HTML — zero JavaScript required for job entry expand/collapse
- Theme's existing panel open/close animation works for all 5 new nav targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)