### PR TITLE
Fix nav icon and quick stats strip visibility bugs

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2002,6 +2002,11 @@ blockquote {
     display: none !important;
 }
 
+/* Override #header > * { margin-top: 3.5rem } — ID selector wins the specificity battle */
+#header .cb-quickstats {
+    margin-top: 1.25rem;
+}
+
 .cb-quickstats a {
     color: inherit;
     border-bottom: none;

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 					<li><a href="#work"><i class="icon solid fa-briefcase"></i> Work</a></li>
 					<li><a href="#skills"><i class="icon solid fa-code"></i> Skills</a></li>
 					<li><a href="#education"><i class="icon solid fa-graduation-cap"></i> Education</a></li>
-					<li><a href="#blog"><i class="icon solid fa-pen-alt"></i> Blog</a></li>
+					<li><a href="#blog"><i class="icon solid fa-blog"></i> Blog</a></li>
 					<li><a href="#contact"><i class="icon solid fa-envelope"></i> Contact</a></li>
 				</ul>
 			</nav>


### PR DESCRIPTION
## Summary

Two UI bugs spotted on the deployed site after PR #5 merged.

## Fixes

- **Wrong Blog icon** — `fa-pen-alt` is not included in the bundled Font Awesome CSS, causing it to fall back to an unrelated glyph (scissors). Replaced with `fa-blog` which is confirmed in the bundle.
- **Quick stats strip invisible** — The theme's `#header > * { margin-top: 3.5rem }` rule (ID + child specificity) was overriding the strip's `margin-top: 1.5rem` (single class), pushing it off-screen. Added `#header .cb-quickstats { margin-top: 1.25rem }` with matching specificity to fix.

## Files changed

- `index.html` — `fa-pen-alt` → `fa-blog`
- `assets/css/main.css` — added `#header .cb-quickstats` margin override

🤖 Generated with [Claude Code](https://claude.com/claude-code)