### PR TITLE
Fix floating + toggle icon escaping Work panel corner

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1726,6 +1726,7 @@ input, select, textarea {
     cursor: pointer;
     outline: none;
     transition: opacity 0.2s ease-in-out;
+    position: relative;
 }
 
 .cb-job summary:hover {
@@ -1745,7 +1746,6 @@ input, select, textarea {
     grid-template-columns: 1fr;
     gap: 0.1rem 0;
     padding-right: 1.5rem;
-    position: relative;
 }
 
 .cb-job summary::after {


### PR DESCRIPTION
## Summary

Bug fix for a misplaced `+` icon visible in the top-right corner of the Work panel.

## Root cause

The `summary::after` pseudo-element (the +/− toggle indicator for collapsible job entries) uses `position: absolute`. Its containing block was set via `position: relative` on `.cb-job-header`, which is a **child** of `summary` — a child element cannot contain a parent's pseudo-element. So the `::after` escaped up the DOM to the nearest positioned ancestor, which turned out to be the article panel itself, landing the `+` in the panel's top-right corner next to the close button.

## Fix

Moved `position: relative` from `.cb-job-header` to `.cb-job summary`. The pseudo-element now positions correctly within its own summary row.

## Files changed

- `assets/css/main.css` — `position: relative` moved from `.cb-job-header` to `.cb-job summary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)