### PR TITLE
Fix Education nav overlapping lines (use-middle CSS conflict)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2043,6 +2043,17 @@ blockquote {
     }
 }
 
+/* --- Suppress use-middle nav behaviour (6 items = even, triggers vertical line through Education) --- */
+/* The theme JS adds use-middle + is-middle on even item counts. With 6 items this draws a line
+   through Education and removes its left border, causing overlapping lines. Suppress both effects. */
+#header nav.use-middle::after {
+    display: none;
+}
+
+#header nav ul li.is-middle {
+    border-left: solid 1px #ffffff;
+}
+
 /* === End custom CV additions === */
 
 /* --- Blog article cards --- */


### PR DESCRIPTION
## Summary

The Education nav button had overlapping/extra lines caused by the theme's `use-middle` behaviour being triggered by having an even number of nav items (6).

## Root cause

`main.js` line 61–66: when nav item count is even, the theme adds `use-middle` to the `<nav>` and `is-middle` to the middle item (index `6/2 = 3` = Education). This:
1. Draws an absolute-positioned vertical white line through the centre of the nav (`nav.use-middle::after`)
2. Removes the left border from the Education `<li>` (`li.is-middle { border-left: 0 }`)

The line + missing border creates the visual overlap on the Education button.

## Fix

Suppress both CSS effects — the vertical connector line isn't needed with 6 nav items, and the Education border should match all other items.

```css
#header nav.use-middle::after { display: none; }
#header nav ul li.is-middle { border-left: solid 1px #ffffff; }
```

## Files changed

- `assets/css/main.css` — two override rules added to custom block

🤖 Generated with [Claude Code](https://claude.com/claude-code)