### PR TITLE
Fix missing Skills/Education nav border (CSS specificity)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2050,7 +2050,7 @@ blockquote {
     display: none;
 }
 
-#header nav ul li.is-middle {
+#header nav.use-middle ul li.is-middle {
     border-left: solid 1px #ffffff;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #8 — the border between Skills and Education was still missing after that fix.

## Root cause

PR #8 added `#header nav ul li.is-middle { border-left: solid 1px #ffffff }` to restore the border, but the theme's rule is `#header nav.use-middle ul li.is-middle { border-left: 0 }` — which has higher specificity due to the `.use-middle` class. The theme was winning and keeping the border at 0.

## Fix

Changed the override selector to exactly match the theme's specificity:

```css
/* before */
#header nav ul li.is-middle { border-left: solid 1px #ffffff; }

/* after */
#header nav.use-middle ul li.is-middle { border-left: solid 1px #ffffff; }
```

## Files changed

- `assets/css/main.css` — selector updated to match theme specificity

🤖 Generated with [Claude Code](https://claude.com/claude-code)