### PR TITLE
Polish pass: chips, copy, SEO, location, cleanup

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -179,9 +179,13 @@ input, select, textarea {
 		font-weight: 600;
 		line-height: 1.5;
 		margin: 0 0 1rem 0;
-		text-transform: uppercase;
 		letter-spacing: 0.2rem;
 	}
+
+		h1.major, h2.major, h3.major, h4.major, h5.major, h6.major {
+			text-transform: uppercase;
+			letter-spacing: 0.5rem;
+		}
 
 		h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
 			color: inherit;
@@ -201,13 +205,13 @@ input, select, textarea {
 	h1 {
 		font-size: 2.25rem;
 		line-height: 1.3;
-		letter-spacing: 0.5rem;
+		letter-spacing: 0.05rem;
 	}
 
 	h2 {
 		font-size: 1.5rem;
 		line-height: 1.4;
-		letter-spacing: 0.5rem;
+		letter-spacing: 0.05rem;
 	}
 
 	h3 {
@@ -719,6 +723,7 @@ input, select, textarea {
 			}
 
 		}
+
 
 /* List */
 
@@ -2122,57 +2127,7 @@ blockquote {
     opacity: 0.7;
 }
 
-/* --- Skill bars --- */
-.cb-skillgroup {
-    margin-bottom: 0.5rem;
-}
-
-.cb-skill-bar-row {
-    display: flex;
-    align-items: center;
-    gap: 0.6rem;
-    margin-bottom: 0.55rem;
-}
-
-.cb-skill-label {
-    font-size: 0.78rem;
-    width: 11rem;
-    flex-shrink: 0;
-    white-space: normal;
-    line-height: 1.35;
-}
-
-.cb-skill-track {
-    flex: 1;
-    height: 6px;
-    background-color: rgba(255, 255, 255, 0.1);
-    border-radius: 3px;
-    overflow: hidden;
-}
-
-.cb-skill-fill {
-    height: 100%;
-    width: 0;
-    border-radius: 3px;
-    background: linear-gradient(90deg, var(--cb-accent-dark, #0066cc), var(--cb-accent, #4facfe));
-    box-shadow: 0 0 8px rgba(79, 172, 254, 0.5);
-    transition: width 1.1s ease-out;
-}
-
-.cb-skill-pct {
-    font-size: 0.7rem;
-    width: 2.4rem;
-    text-align: right;
-    flex-shrink: 0;
-    opacity: 0.5;
-    letter-spacing: 0.04rem;
-}
-
 @media screen and (max-width: 480px) {
-    .cb-skill-label {
-        width: 8rem;
-        font-size: 0.73rem;
-    }
     .cb-article-footer {
         flex-direction: column;
         align-items: flex-start;

--- a/index.html
+++ b/index.html
@@ -7,9 +7,13 @@
 <html>
 
 <head>
-	<title>Charl Brill</title>
+	<title>Charl Brill — Senior Data Engineer</title>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+	<meta name="description" content="Charl Brill — Senior Data Engineer specialising in Microsoft Fabric, Databricks, and AWS. Building data platforms and pipelines that scale." />
+	<meta property="og:title" content="Charl Brill — Senior Data Engineer" />
+	<meta property="og:description" content="Senior Data Engineer specialising in Microsoft Fabric, Databricks, and AWS. Building data platforms and pipelines that scale." />
+	<meta property="og:type" content="website" />
 	<link rel="stylesheet" href="assets/css/main.css" />
 	<link rel="icon" href="images/favicon_Charl.ico">
 
@@ -35,7 +39,7 @@
 			<div class="content">
 				<div class="inner">
 					<h1>Hi, I'm Charl Brill</h1>
-					<p>Senior Data Engineer &middot; Microsoft Fabric &middot; Databricks &middot; AWS &middot; Azure<br />Turning complex data challenges into scalable solutions.</p>
+					<p>Senior Data Engineer &middot; Microsoft Fabric &middot; Databricks &middot; AWS &middot; Azure<br />From raw data to reliable decisions — I build the platforms and pipelines that make it happen.</p>
 				</div>
 			</div>
 			<nav>
@@ -51,7 +55,7 @@
 
 			<!-- Quick stats strip: key facts visible without clicking into any section -->
 			<div class="cb-quickstats">
-				<span><i class="icon solid fa-map-marker-alt"></i> Maple Ridge, BC</span>
+				<span><i class="icon solid fa-map-marker-alt"></i> Vancouver, BC</span>
 				<span><i class="icon solid fa-briefcase"></i> Senior Data Engineer</span>
 				<span><i class="icon brands fa-linkedin"></i><a href="https://www.linkedin.com/in/charl-brill-33142166/" target="_blank" rel="noopener"> LinkedIn</a></span>
 				<span><i class="icon brands fa-github"></i><a href="https://github.com/CharlBrill89" target="_blank" rel="noopener"> GitHub</a></span>
@@ -61,21 +65,12 @@
 		<!-- Main -->
 		<div id="main">
 
-			<!-- Intro -->
-			<article id="intro">
-				<h2 class="major">Intro</h2>
-				<span class="image main"><img src="images/pic01.jpg" alt="" /></span>
-
-			</article>
-
 			<!-- Work -->
 			<article id="work">
 				<h2 class="major">Work</h2>
 				<ul class="actions">
 					<li><a href="https://drive.google.com/file/d/1GP0ZYQAYqImh8qYZ3ZlEsEh-K8rXhb8_/view?usp=sharing" target="_blank" class="button primary icon solid fa-file-alt">View Resume</a></li>
 				</ul>
-				<span class="image main"><img src="images/nordwood-themes-bJjsKbToY34-unsplash.jpg" alt="Work" /></span>
-
 				<div class="cb-timeline">
 
 					<details class="cb-job">
@@ -202,41 +197,41 @@
 				<h2 class="major">Skills</h2>
 
 				<h3 class="cb-skill-category"><i class="icon solid fa-cloud"></i> Cloud Platforms</h3>
-				<section class="cb-skillgroup">
-					<div class="cb-skill-bar-row" data-pct="90"><span class="cb-skill-label">Microsoft Fabric</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">90%</span></div>
-					<div class="cb-skill-bar-row" data-pct="88"><span class="cb-skill-label">Azure Databricks</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">88%</span></div>
-					<div class="cb-skill-bar-row" data-pct="85"><span class="cb-skill-label">Azure (ADF, Key Vault)</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">85%</span></div>
-					<div class="cb-skill-bar-row" data-pct="80"><span class="cb-skill-label">AWS</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">80%</span></div>
-					<div class="cb-skill-bar-row" data-pct="72"><span class="cb-skill-label">AWS Glue</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">72%</span></div>
-				</section>
+				<div class="cb-chips">
+					<span class="cb-chip">Microsoft Fabric</span>
+					<span class="cb-chip">Azure Databricks</span>
+					<span class="cb-chip">Azure (ADF, Key Vault)</span>
+					<span class="cb-chip">AWS</span>
+					<span class="cb-chip">AWS Glue</span>
+				</div>
 
 				<h3 class="cb-skill-category"><i class="icon solid fa-database"></i> Data Engineering</h3>
-				<section class="cb-skillgroup">
-					<div class="cb-skill-bar-row" data-pct="92"><span class="cb-skill-label">SQL</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">92%</span></div>
-					<div class="cb-skill-bar-row" data-pct="92"><span class="cb-skill-label">ETL / ELT</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">92%</span></div>
-					<div class="cb-skill-bar-row" data-pct="90"><span class="cb-skill-label">Python</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">90%</span></div>
-					<div class="cb-skill-bar-row" data-pct="88"><span class="cb-skill-label">PySpark</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">88%</span></div>
-					<div class="cb-skill-bar-row" data-pct="85"><span class="cb-skill-label">Data Modeling</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">85%</span></div>
-					<div class="cb-skill-bar-row" data-pct="75"><span class="cb-skill-label">dbt</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">75%</span></div>
-				</section>
+				<div class="cb-chips">
+					<span class="cb-chip">SQL</span>
+					<span class="cb-chip">ETL / ELT</span>
+					<span class="cb-chip">Python</span>
+					<span class="cb-chip">PySpark</span>
+					<span class="cb-chip">Data Modeling</span>
+					<span class="cb-chip">dbt</span>
+				</div>
 
 				<h3 class="cb-skill-category"><i class="icon solid fa-chart-bar"></i> BI &amp; Analytics</h3>
-				<section class="cb-skillgroup">
-					<div class="cb-skill-bar-row" data-pct="90"><span class="cb-skill-label">Power BI</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">90%</span></div>
-					<div class="cb-skill-bar-row" data-pct="80"><span class="cb-skill-label">Qlik Sense / QlikView</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">80%</span></div>
-					<div class="cb-skill-bar-row" data-pct="75"><span class="cb-skill-label">Alteryx</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">75%</span></div>
-					<div class="cb-skill-bar-row" data-pct="72"><span class="cb-skill-label">Metabase</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">72%</span></div>
-					<div class="cb-skill-bar-row" data-pct="70"><span class="cb-skill-label">Tableau</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">70%</span></div>
-				</section>
+				<div class="cb-chips">
+					<span class="cb-chip">Power BI</span>
+					<span class="cb-chip">Qlik Sense / QlikView</span>
+					<span class="cb-chip">Alteryx</span>
+					<span class="cb-chip">Metabase</span>
+					<span class="cb-chip">Tableau</span>
+				</div>
 
 				<h3 class="cb-skill-category"><i class="icon solid fa-tools"></i> Tools &amp; Methods</h3>
-				<section class="cb-skillgroup">
-					<div class="cb-skill-bar-row" data-pct="85"><span class="cb-skill-label">Agile / Product Mgmt</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">85%</span></div>
-					<div class="cb-skill-bar-row" data-pct="85"><span class="cb-skill-label">Jira / Confluence</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">85%</span></div>
-					<div class="cb-skill-bar-row" data-pct="82"><span class="cb-skill-label">Git / DevOps</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">82%</span></div>
-					<div class="cb-skill-bar-row" data-pct="80"><span class="cb-skill-label">Excel VBA</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">80%</span></div>
-					<div class="cb-skill-bar-row" data-pct="78"><span class="cb-skill-label">MLOps / AI Pilots</span><div class="cb-skill-track"><div class="cb-skill-fill"></div></div><span class="cb-skill-pct">78%</span></div>
-				</section>
+				<div class="cb-chips">
+					<span class="cb-chip">Agile / Product Mgmt</span>
+					<span class="cb-chip">Jira / Confluence</span>
+					<span class="cb-chip">Git / DevOps</span>
+					<span class="cb-chip">Excel VBA</span>
+					<span class="cb-chip">MLOps / AI Pilots</span>
+				</div>
 			</article>
 
 			<!-- Education -->
@@ -319,7 +314,7 @@
 					</div>
 					<div class="cb-article-footer">
 						<small class="cb-article-date">May 2026</small>
-						<a href="https://www.linkedin.com/in/charl-brill-33142166/" target="_blank" rel="noopener" class="cb-article-link">Read on LinkedIn <i class="icon solid fa-external-link-alt"></i></a>
+						<a href="https://www.linkedin.com/pulse/hidden-cost-tool-sprawl-charl-brill-dj3lc/" target="_blank" rel="noopener" class="cb-article-link">Read on LinkedIn <i class="icon solid fa-external-link-alt"></i></a>
 					</div>
 				</div>
 
@@ -333,7 +328,7 @@
 					</div>
 					<div class="cb-article-footer">
 						<small class="cb-article-date">April 2026</small>
-						<a href="https://www.linkedin.com/in/charl-brill-33142166/" target="_blank" rel="noopener" class="cb-article-link">Read on LinkedIn <i class="icon solid fa-external-link-alt"></i></a>
+						<a href="https://www.linkedin.com/pulse/fabcon-2026-microsoft-fabrics-cicd-moment-has-arrived-charl-brill-ndusf/" target="_blank" rel="noopener" class="cb-article-link">Read on LinkedIn <i class="icon solid fa-external-link-alt"></i></a>
 					</div>
 				</div>
 
@@ -347,7 +342,7 @@
 					</div>
 					<div class="cb-article-footer">
 						<small class="cb-article-date">February 2026</small>
-						<a href="https://www.linkedin.com/in/charl-brill-33142166/" target="_blank" rel="noopener" class="cb-article-link">Read on LinkedIn <i class="icon solid fa-external-link-alt"></i></a>
+						<a href="https://www.linkedin.com/pulse/why-your-data-pipelines-costing-you-more-than-think-what-charl-brill-v4rjc/" target="_blank" rel="noopener" class="cb-article-link">Read on LinkedIn <i class="icon solid fa-external-link-alt"></i></a>
 					</div>
 				</div>
 
@@ -356,13 +351,13 @@
 			<!-- About -->
 			<article id="about">
 				<h2 class="major">About</h2>
-				<span class="image main"><img src="images/andy-hermawan-bVBvv5xlX3g-unsplash.jpg" alt="About" /></span>
 				<blockquote>Engineer by trade, problem solver by passion.</blockquote>
-				<p>An experienced data professional who combines a systems thinking mindset (engineering) with critical reasoning skills (MBA). Driven by the need to use data, analytics and strategic reasoning to ensure evidence-based decision making for future generations.</p>
+				<p>Mechanical engineer turned data engineer — with an MBA in between. That combination gives me an unusual lens: I think in systems, reason in outcomes, and build for scale.</p>
+				<p>Over a decade across data engineering, analytics consulting, and product leadership — in South Africa and Canada — has shaped a clear point of view: the best data solutions are the ones people actually trust and use. Whether I'm architecting a medallion lakehouse on Microsoft Fabric, designing ETL pipelines in Databricks, or advising on data strategy, the goal is always the same: turn complexity into clarity.</p>
 				<div class="cb-highlights">
 					<div class="cb-highlight-item">
 						<span class="cb-highlight-label"><i class="icon solid fa-map-marker-alt"></i> Location</span>
-						<span class="cb-highlight-value">Maple Ridge, BC, Canada</span>
+						<span class="cb-highlight-value">Vancouver, BC, Canada</span>
 					</div>
 					<div class="cb-highlight-item">
 						<span class="cb-highlight-label"><i class="icon solid fa-building"></i> Current Role</span>
@@ -687,50 +682,6 @@ print 'It took ' + i + ' iterations to sort the deck.';</code></pre>
 	<script src="assets/js/breakpoints.min.js"></script>
 	<script src="assets/js/util.js"></script>
 	<script src="assets/js/main.js"></script>
-
-<script>
-(function () {
-    var skillsArticle = document.getElementById('skills');
-    if (!skillsArticle) return;
-
-    function animateBars() {
-        var rows = skillsArticle.querySelectorAll('.cb-skill-bar-row');
-        rows.forEach(function (row, i) {
-            var fill = row.querySelector('.cb-skill-fill');
-            var pct  = row.getAttribute('data-pct');
-            if (!fill || !pct) return;
-            fill.style.transitionDelay = (i * 50) + 'ms';
-            requestAnimationFrame(function () {
-                requestAnimationFrame(function () {
-                    fill.style.width = pct + '%';
-                });
-            });
-        });
-    }
-
-    function resetBars() {
-        var fills = skillsArticle.querySelectorAll('.cb-skill-fill');
-        fills.forEach(function (fill) {
-            fill.style.transitionDelay = '0ms';
-            fill.style.width = '0';
-        });
-    }
-
-    var observer = new MutationObserver(function (mutations) {
-        mutations.forEach(function (mutation) {
-            if (mutation.attributeName === 'class') {
-                if (skillsArticle.classList.contains('is-active')) {
-                    animateBars();
-                } else {
-                    resetBars();
-                }
-            }
-        });
-    });
-
-    observer.observe(skillsArticle, { attributes: true });
-}());
-</script>
 </body>
 
 </html>


### PR DESCRIPTION
## What changed

- **Skills** — replaced percentage bars with a chip/tag grid; arbitrary self-scored percentages removed
- **All-caps headings** — scoped `text-transform: uppercase` to `.major` headings only; landing h1 now renders in natural mixed case
- **Section images** — removed outdated Unsplash photos from Work and About panels
- **About bio** — full rewrite: specific, confident, earns the engineering + MBA angle rather than just asserting it
- **Landing tagline** — replaced generic "Turning complex data challenges…" with "From raw data to reliable decisions — I build the platforms and pipelines that make it happen."
- **Location** — updated Maple Ridge → Vancouver, BC in quick stats strip and About highlights
- **Blog links** — wired up real LinkedIn Pulse URLs for all three articles (were pointing to profile page)
- **SEO** — added `<meta name="description">` and Open Graph tags (`og:title`, `og:description`, `og:type`) to `<head>`; page `<title>` updated to include role

## Cleanup

- Removed empty `#intro` article (placeholder image, not in nav)
- Removed dead skill-bar CSS (~50 lines: `.cb-skillgroup`, `.cb-skill-bar-row`, `.cb-skill-track`, `.cb-skill-fill`, `.cb-skill-pct`)
- Removed bar animation `<script>` block
- Removed leftover `cb-section-banner` div and all associated CSS/keyframes

🤖 Generated with [Claude Code](https://claude.com/claude-code)